### PR TITLE
Removed event type comparison in lecture detection

### DIFF
--- a/client/detect-duplicates.js
+++ b/client/detect-duplicates.js
@@ -4,8 +4,11 @@ export function detectDuplicates(courses) {
     const days = courses[courseKey].days;
     for (const dayKey in days) {
       const day = days[dayKey];
-      for (const event1 of day) {
-        for (const event2 of day) {
+
+      for (let i = 0; i < day.length; i++) {
+        const event1 = day[i];
+        for (let j = i + 1; j < day.length; j++) {
+          const event2 = day[j];
           if (isDuplicateEvent(event1, event2)) {
             if (!duplicates[courseKey]) {
               duplicates[courseKey] = {};

--- a/client/detect-duplicates.js
+++ b/client/detect-duplicates.js
@@ -53,7 +53,6 @@ export function isDuplicateEvent(event1, event2) {
     return false;
   }
   return (
-    event1.type === event2.type &&
     event1.startTime === event2.startTime &&
     event1.endTime === event2.endTime &&
     arraysAreEqual(event1.weeks, event2.weeks)


### PR DESCRIPTION
This would cause an issues with groups so it was removed since "Lecture-Grp2" and "Lecture-Grp1" wouldn't be considered duplicates. However, it would make sense to mark them as duplicates because you would typically only want to add one.

Changes weren't tested :P